### PR TITLE
Feat: Add support for clamped constraints

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SpecialSpaces"
 uuid = "cc3e65be-d4cb-4562-9ae2-5262579a9956"
 authors = ["Michał Mika <michal@mika.sh>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 AbstractMappings = "7dac2afd-1bf6-47b8-bc94-9dcdcd19d527"
@@ -30,6 +30,8 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SortedSequences = "2f2e3dc8-c2cf-4b7f-b456-36845a1cbdbc"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UnivariateSplines = "2552f6ce-f0d6-4ba3-bf39-bb338613ee69"
+AbstractMappings = "7dac2afd-1bf6-47b8-bc94-9dcdcd19d527"
+IgaBase = "9c103fa8-ae55-49f5-92db-ab77803cf2c4"
 
 [targets]
-test = ["Test", "SafeTestsets", "CartesianProducts", "KroneckerProducts", "SortedSequences", "UnivariateSplines", "LinearAlgebra"]
+test = ["Test", "SafeTestsets", "CartesianProducts", "KroneckerProducts", "SortedSequences", "UnivariateSplines", "LinearAlgebra", "AbstractMappings", "IgaBase"]

--- a/src/SpecialSpaces.jl
+++ b/src/SpecialSpaces.jl
@@ -9,6 +9,7 @@ module SpecialSpaces
     using TensorProductBsplines
 
     include("base.jl")
+    include("boundaries.jl")
     include("constraints.jl")
     include("spaces.jl")
     include("splinespaces.jl")
@@ -26,6 +27,8 @@ module SpecialSpaces
     export MixedSplineSpaceConstraints
     export extraction_operator, extraction_operators
     export left_constraint!, right_constraint!, periodic_constraint!
+    export clamped_constraint!
     export setcoeffs!, getcoeffs
+    export boundary_symbol, boundary_number
 
 end # module

--- a/src/boundaries.jl
+++ b/src/boundaries.jl
@@ -1,0 +1,45 @@
+"""
+    boundary_number(s::Symbol)
+
+Return the boundary number corresponding to boundary `s`.
+
+```
+                                               5
+                            4                 back
+                           top                  . . . . . . .
+                     . . . . . . . .            . .         . .
+y                    .             .            .   .       .   .
+.                    .             .            .     . . . . . . .
+.             left   .             .  right     .     .     .     .
+.               1    .             .    2       .     .     .     .
+· · · ·  x           .             .            . . . . . . .     .
+  ·                  . . . . . . . .              .   .       .   .
+    ·                    bottom                     . .         . .
+      z                     3                         . . . . . . .
+                                                                 front
+                                                                   6
+```
+"""
+boundary_number(s::Symbol) = boundary_number(Val(s))
+boundary_number(::Val{:left}) = 1
+boundary_number(::Val{:right}) = 2
+boundary_number(::Val{:bottom}) = 3
+boundary_number(::Val{:top}) = 4
+boundary_number(::Val{:back}) = 5
+boundary_number(::Val{:front}) = 6
+
+"""
+    boundary_symbol(s::Int)
+
+Return the boundary label (symbol) for boundary number `s`.
+"""
+boundary_symbol(s::Int) = boundary_symbol(Val(s))
+boundary_symbol(::Val{1}) = :left
+boundary_symbol(::Val{2}) = :right
+boundary_symbol(::Val{3}) = :bottom
+boundary_symbol(::Val{4}) = :top
+boundary_symbol(::Val{5}) = :back
+boundary_symbol(::Val{6}) = :front
+
+check_boundary_label(::Val{2}, s::Symbol) = s in [:left, :right, :top, :bottom]
+check_boundary_label(::Val{3}, s::Symbol) = s in [:left, :right, :top, :bottom, :back, :front]

--- a/src/boundaries.jl
+++ b/src/boundaries.jl
@@ -8,14 +8,14 @@ Return the boundary number corresponding to boundary `s`.
                             4                 back
                            top                  . . . . . . .
                      . . . . . . . .            . .         . .
-y                    .             .            .   .       .   .
+η                    .             .            .   .       .   .
 .                    .             .            .     . . . . . . .
 .             left   .             .  right     .     .     .     .
 .               1    .             .    2       .     .     .     .
-· · · ·  x           .             .            . . . . . . .     .
+· · · ·  ξ           .             .            . . . . . . .     .
   ·                  . . . . . . . .              .   .       .   .
     ·                    bottom                     . .         . .
-      z                     3                         . . . . . . .
+      ζ                     3                         . . . . . . .
                                                                  front
                                                                    6
 ```

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -154,34 +154,37 @@ Type alias for `NamedTuple` which serves as a container for mixed space constrai
 const MixedSplineSpaceConstraints = NamedTuple
 
 """
-    left_constraint!(C::ScalarSplineSpaceConstraints; c::Vector{Int}=Int[1], dim::Int)
+    left_constraint!(C::ScalarSplineSpaceConstraints{Dim}; c::Vector{Int}=Int[1], dim::Int) where {Dim}
 
 Push `c` to vector in `left` field of [`UnivariateSplineSpaceConstraints`](@ref)
 stored at index `dim` in [`ScalarSplineSpaceConstraints`](@ref).
 """
-function left_constraint!(C::ScalarSplineSpaceConstraints; c::Vector{Int}=Int[1], dim::Int)
+function left_constraint!(C::ScalarSplineSpaceConstraints{Dim}; c::Vector{Int}=Int[1], dim::Int) where {Dim}
+    @assert dim ≤ Dim
     push!(C[dim].left, c...)
     return C
 end
 
 """
-    right_constraint!(C::ScalarSplineSpaceConstraints; c::Vector{Int}=Int[1], dim::Int)
+    right_constraint!(C::ScalarSplineSpaceConstraints{Dim}; c::Vector{Int}=Int[1], dim::Int) where {Dim}
 
 Push `c` to vector in `right` field of [`UnivariateSplineSpaceConstraints`](@ref)
 stored at index `dim` in [`ScalarSplineSpaceConstraints`](@ref).
 """
-function right_constraint!(C::ScalarSplineSpaceConstraints; c::Vector{Int}=Int[1], dim::Int)
+function right_constraint!(C::ScalarSplineSpaceConstraints{Dim}; c::Vector{Int}=Int[1], dim::Int) where {Dim}
+    @assert dim ≤ Dim
     push!(C[dim].right, c...)
     return C
 end
 
 """
-    periodic_constraint!(C::ScalarSplineSpaceConstraints; c::Vector{Int}, dim::Int)
+    periodic_constraint!(C::ScalarSplineSpaceConstraints{Dim}; c::Vector{Int}, dim::Int) where {Dim}
 
 Push `c` to vector in `periodic` field of [`UnivariateSplineSpaceConstraints`](@ref)
 stored at index `dim` in [`ScalarSplineSpaceConstraints`](@ref).
 """
-function periodic_constraint!(C::ScalarSplineSpaceConstraints; c::Vector{Int}, dim::Int)
+function periodic_constraint!(C::ScalarSplineSpaceConstraints{Dim}; c::Vector{Int}, dim::Int) where {Dim}
+    @assert dim ≤ Dim
     push!(C[dim].periodic, c...)
     return C
 end
@@ -197,3 +200,51 @@ end
 function Base.show(io::IO, ::C) where {Dim,Codim,T<:Integer,C<:VectorSplineSpaceConstraints{Dim,Codim,T}}
     print(io, C)
 end
+
+"""
+    clamped_constraint!(C::ScalarSplineSpaceConstraints, side::Vararg{Symbol,N}) where {N}
+
+Clamp a scalar spline space at `side`, where `side` is one of the boundary labels:
+- `:left`
+- `:right`
+- `:bottom`
+- `:top`
+- `:back`
+- `:front`
+"""
+function clamped_constraint!(C::ScalarSplineSpaceConstraints{Dim}, side::Vararg{Symbol,N}) where {Dim,N}
+    @assert all(check_boundary_label.(Val(Dim), side)) "invalid boundary label"
+    for k in Base.OneTo(N)
+        clamped_constraint!(C, Val(side[k]))
+    end
+end
+clamped_constraint!(C::ScalarSplineSpaceConstraints, ::Val{:left})   = left_constraint!(C; dim=1)
+clamped_constraint!(C::ScalarSplineSpaceConstraints, ::Val{:right})  = right_constraint!(C; dim=1)
+clamped_constraint!(C::ScalarSplineSpaceConstraints, ::Val{:bottom}) = left_constraint!(C; dim=2)
+clamped_constraint!(C::ScalarSplineSpaceConstraints, ::Val{:top})    = right_constraint!(C; dim=2)
+clamped_constraint!(C::ScalarSplineSpaceConstraints, ::Val{:back})   = left_constraint!(C; dim=3)
+clamped_constraint!(C::ScalarSplineSpaceConstraints, ::Val{:front})  = right_constraint!(C; dim=3)
+
+"""
+    clamped_constraint!(C::VectorSplineSpaceConstraints{Dim}, side::Vararg{Symbol,N}; dim=1:Dim) where {Dim,N}
+
+Clamp a vector spline space in dimensions `dim` at `side`, where `side` is one of the boundary labels:
+- `:left`
+- `:right`
+- `:bottom`
+- `:top`
+- `:back`
+- `:front`
+"""
+function clamped_constraint!(C::VectorSplineSpaceConstraints{Dim}, side::Vararg{Symbol,N}; dim=1:Dim) where {Dim,N}
+    @assert all(check_boundary_label.(Val(Dim), side)) "invalid boundary label"
+    for k in Base.OneTo(N)
+        clamped_constraint!(C, Val(side[k]); dim=dim)
+    end
+end
+clamped_constraint!(C::VectorSplineSpaceConstraints{Dim}, ::Val{:left}  ; dim=1:Dim) where {Dim} = map(d -> left_constraint!(C[d] ; dim=1), dim)
+clamped_constraint!(C::VectorSplineSpaceConstraints{Dim}, ::Val{:right} ; dim=1:Dim) where {Dim} = map(d -> right_constraint!(C[d]; dim=1), dim)
+clamped_constraint!(C::VectorSplineSpaceConstraints{Dim}, ::Val{:bottom}; dim=1:Dim) where {Dim} = map(d -> left_constraint!(C[d] ; dim=2), dim)
+clamped_constraint!(C::VectorSplineSpaceConstraints{Dim}, ::Val{:top}   ; dim=1:Dim) where {Dim} = map(d -> right_constraint!(C[d]; dim=2), dim)
+clamped_constraint!(C::VectorSplineSpaceConstraints{Dim}, ::Val{:back}  ; dim=1:Dim) where {Dim} = map(d -> left_constraint!(C[d] ; dim=3), dim)
+clamped_constraint!(C::VectorSplineSpaceConstraints{Dim}, ::Val{:front} ; dim=1:Dim) where {Dim} = map(d -> right_constraint!(C[d]; dim=3), dim)

--- a/test/boundaries.jl
+++ b/test/boundaries.jl
@@ -1,0 +1,28 @@
+@testset "Boundary labels" begin
+    @test boundary_symbol(1) == :left
+    @test boundary_symbol(2) == :right
+    @test boundary_symbol(3) == :bottom
+    @test boundary_symbol(4) == :top
+    @test boundary_symbol(5) == :back
+    @test boundary_symbol(6) == :front
+
+    @test boundary_number(:left) == 1
+    @test boundary_number(:right) == 2
+    @test boundary_number(:bottom) == 3
+    @test boundary_number(:top) == 4
+    @test boundary_number(:back) == 5
+    @test boundary_number(:front) == 6
+end
+
+@testset "Check validity of boundary label" begin
+    @test SpecialSpaces.check_boundary_label(Val(2), :left) == true
+    @test SpecialSpaces.check_boundary_label(Val(2), :front) == false
+    @test SpecialSpaces.check_boundary_label(Val(2), :foo) == false
+    @test SpecialSpaces.check_boundary_label(Val(3), :left) == true
+    @test SpecialSpaces.check_boundary_label(Val(3), :front) == true
+    @test SpecialSpaces.check_boundary_label(Val(3), :foo) == false
+    @test all(SpecialSpaces.check_boundary_label.(Val(2), (:left, :right))) == true
+    @test all(SpecialSpaces.check_boundary_label.(Val(2), (:left, :front))) == false
+    @test all(SpecialSpaces.check_boundary_label.(Val(3), (:left, :front))) == true
+    @test all(SpecialSpaces.check_boundary_label.(Val(3), (:left, :foo))) == false
+end

--- a/test/constraints.jl
+++ b/test/constraints.jl
@@ -1,3 +1,5 @@
+using IgaBase, AbstractMappings
+
 @testset "Univariate spline space constraints" begin
     # init univariate spline constraints container
     C = UnivariateSplineSpaceConstraints{Int64}()
@@ -104,4 +106,102 @@ end
 
     @test C.V[2][1].right == [1]
     @test C.V[2][2].right == [1,2]
+end
+
+@testset "Clamped scalar spline spaces" begin
+    # mapping domain
+    Ω = Interval(1.0, 2.0) ⨱ Interval(3.0, 4.0) ⨱ Interval(5.0, 6.0)
+
+    # mapping partition
+    Δ = Partition(Ω, (5, 5, 5))
+
+    # proto scalar spline space
+    S = ScalarSplineSpace(2, Δ)
+
+    
+    # test constant mapping without any constraints
+    fʰ = GeometricMapping(Ω, S)
+    fʰ[1].coeffs .= 1.0
+    @evaluate y = fʰ(Δ)
+    @test all(y .== 1.0)
+
+    # test constant mapping with clamped constraint on :left and :bottom
+    C = ScalarSplineSpaceConstraints(S)
+    clamped_constraint!(C, :left, :bottom)
+
+    fʰ = GeometricMapping(Ω, ScalarSplineSpace(S,C))
+    fʰ[1].coeffs .= 1.0
+    @evaluate y = fʰ(Δ)
+    @test all(boundary(y, boundary_number(:left)) .== 0.0)
+    @test all(boundary(y, boundary_number(:bottom)) .== 0.0)
+
+    # test constant mapping with clamped constraint on each boundary
+    for side = [:left, :right, :bottom, :top, :back, :front]
+        C = ScalarSplineSpaceConstraints(S)
+        clamped_constraint!(C, side)
+
+        fʰ = GeometricMapping(Ω, ScalarSplineSpace(S,C))
+        fʰ[1].coeffs .= 1.0
+        @evaluate y = fʰ(Δ)
+        @test all(boundary(y, boundary_number(side)) .== 0)
+    end
+
+    # test check for valid boundary label
+    @test_throws AssertionError("invalid boundary label") clamped_constraint!(C, :left, :foo)
+end
+
+@testset "Clamped vector spline spaces" begin
+    # mapping domain
+    Ω = Interval(1.0, 2.0) ⨱ Interval(3.0, 4.0) ⨱ Interval(5.0, 6.0)
+
+    # mapping partition
+    Δ = Partition(Ω, (5, 5, 5))
+
+    # proto vector spline space
+    V = VectorSplineSpace(2, Δ)
+
+
+    # test constant mapping without any constraints in each dimension
+    fʰ = GeometricMapping(Ω, V)
+    fʰ[1].coeffs .= 1.0
+    fʰ[2].coeffs .= 2.0
+    fʰ[3].coeffs .= 3.0
+    @evaluate y = fʰ(Δ)
+    @test all(isapprox.(y.data[1], 1.0, atol=1e-12))
+    @test all(isapprox.(y.data[2], 2.0, atol=1e-12))
+    @test all(isapprox.(y.data[3], 3.0, atol=1e-12))
+
+    # test constant mapping with clamped constraint on :left and :right in dimensions 1 and 3
+    C = VectorSplineSpaceConstraints(V)
+    clamped_constraint!(C, :left, :right; dim=[1,3])
+
+    fʰ = GeometricMapping(Ω, VectorSplineSpace(V,C))
+    fʰ[1].coeffs .= 1.0
+    fʰ[2].coeffs .= 2.0
+    fʰ[3].coeffs .= 3.0
+    @evaluate! y = fʰ(Δ)
+    @test all(boundary(y.data[1], boundary_number(:left)) .== 0)
+    @test all(boundary(y.data[2], boundary_number(:left)) .== 2.0)
+    @test all(boundary(y.data[3], boundary_number(:left)) .== 0)
+    @test all(boundary(y.data[1], boundary_number(:right)) .== 0)
+    @test all(boundary(y.data[2], boundary_number(:right)) .== 2.0)
+    @test all(boundary(y.data[3], boundary_number(:right)) .== 0)
+
+    # test constant mapping with clamped constraint on each boundary in all dimensions
+    for side = [:left, :right, :bottom, :top, :back, :front]
+        C = VectorSplineSpaceConstraints(V)
+        clamped_constraint!(C, side)
+
+        fʰ = GeometricMapping(Ω, VectorSplineSpace(V,C))
+        fʰ[1].coeffs .= 1.0
+        fʰ[2].coeffs .= 2.0
+        fʰ[3].coeffs .= 3.0
+        @evaluate y = fʰ(Δ)
+        @test all(boundary(y.data[1], boundary_number(side)) .== 0)
+        @test all(boundary(y.data[2], boundary_number(side)) .== 0)
+        @test all(boundary(y.data[3], boundary_number(side)) .== 0)
+    end
+
+    # test check for valid boundary label
+    @test_throws AssertionError("invalid boundary label") clamped_constraint!(C, :left, :foo)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ tests = [
     "spaces",
     "splinespaces",
     "mappings",
+    "boundaries",
 ]
 
 @testset "SpecialSpaces" begin


### PR DESCRIPTION
```julia
Ω = Interval(1.0, 2.0) ⨱ Interval(3.0, 4.0) ⨱ Interval(5.0, 6.0)
Δ = Partition(Ω, (5, 5, 5))
S = ScalarSplineSpace(2, Δ)
V = VectorSplineSpace(2, Δ)

C = ScalarSplineSpaceConstraints(S)
clamped_constraint!(C, :left, :bottom)

C = VectorSplineSpaceConstraints(V)
clamped_constraint!(C, :left, :right; dim=[1,3])
```